### PR TITLE
Remove duplicate lines

### DIFF
--- a/wordlists/adjectives.txt
+++ b/wordlists/adjectives.txt
@@ -299,7 +299,6 @@ berserk
 best
 betrayed
 better
-better
 better-late-than-never
 bewildered
 bewildering
@@ -561,7 +560,6 @@ chauvinistic
 cheap
 cheaper
 cheapest
-cheapest
 cheeky
 cheekyer
 cheekyest
@@ -805,7 +803,6 @@ cooing
 cooked
 cool
 cooler
-coolest
 coolest
 cooperative
 coordinated
@@ -1554,7 +1551,6 @@ fashionable
 fast
 faster
 fastest
-fastest
 fastidious
 fast-moving
 fat
@@ -1942,7 +1938,6 @@ greasyest
 great
 greater
 greatest
-greatest
 greedy
 greedyer
 greedyest
@@ -2093,7 +2088,6 @@ hideous
 high
 higher
 highest
-highest
 highfalutin
 high-functioning
 high-maintenance
@@ -2134,7 +2128,6 @@ horrified
 horrifying
 hospitable
 hostile
-hot
 hot
 hot-blooded
 hotheaded
@@ -2737,8 +2730,6 @@ lonelyest
 long
 longer
 longest
-longer
-longest
 longing
 long-term
 long-winded
@@ -2767,7 +2758,6 @@ lower
 lowest
 low-calorie
 low-carb
-lower
 low-fat
 lowly
 lowlyer
@@ -3061,7 +3051,6 @@ near
 nearer
 nearest
 nearby
-nearest
 nearsighted
 neat
 neater
@@ -3088,7 +3077,6 @@ neurotic
 neutral
 new
 newer
-newest
 newest
 next
 next-door
@@ -3214,8 +3202,6 @@ oilyest
 OK
 okay
 old
-older
-oldest
 older
 oldest
 old-fashioned
@@ -3491,8 +3477,6 @@ ponderous
 poor
 poorer
 poorest
-poorer
-poorest
 popping
 popular
 populous
@@ -3697,7 +3681,6 @@ quicker
 quickest
 quick-acting
 quick-drying
-quickest
 quick-minded
 quick-paced
 quick-tempered
@@ -3893,8 +3876,6 @@ rewarding
 rhetorical
 rhythmic
 rich
-richer
-richest
 richer
 richest
 ridiculing
@@ -4333,16 +4314,12 @@ slyest
 small
 smaller
 smallest
-smaller
-smallest
 small-minded
 small-scale
 small-time
 small-town
 smarmy
 smart
-smarter
-smartest
 smarter
 smartest
 smashing
@@ -4388,7 +4365,6 @@ snuger
 snugest
 snuggly
 soaked
-soaking
 soaking
 soaring
 sober
@@ -4631,8 +4607,6 @@ striped
 strong
 stronger
 strongest
-stronger
-strongest
 structural
 stubborn
 stubby
@@ -4775,8 +4749,6 @@ take-charge
 talented
 talkative
 tall
-taller
-tallest
 taller
 tallest
 tame
@@ -5586,7 +5558,6 @@ warlike
 warm
 warmer
 warmest
-warmest
 warning
 warring
 wary
@@ -5770,8 +5741,6 @@ worldly
 worldlyer
 worldlyest
 worn
-worn
-worn
 worried
 worrisome
 worrying
@@ -5803,8 +5772,6 @@ yellow
 yelping
 yielding
 young
-younger
-youngest
 younger
 youngest
 youthful


### PR DESCRIPTION
This should take care of duplicate lines. Additional duplicate words exist but they are in the form of multi-word lines. See #3.

I am still weary of how all this erata came to be. If things have been added, is there a chance that things are missing / went lost? I certainly have no idea how this list came to be. I will leave that and the potential creation of a new issue to the maintainer. 